### PR TITLE
check json before decode it

### DIFF
--- a/jquery.ajaxfileupload.js
+++ b/jquery.ajaxfileupload.js
@@ -78,6 +78,7 @@
 				response = doc.body.innerHTML;
 
 			if (response) {
+				response = response.substring(response.indexOf("{"), response.lastIndexOf("}") + 1);
 				response = $.parseJSON(response);
 			} else {
 				response = {};


### PR DESCRIPTION
In some browsers, json value will be wrap by "<pre style="word-wrap: break-word; white-space: pre-wrap;">" if your content-type is not right.
